### PR TITLE
Add timestamp and avoid screen flip

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/mitayun/keycodeauth/MainActivity.java
+++ b/app/src/main/java/com/mitayun/keycodeauth/MainActivity.java
@@ -13,6 +13,7 @@ import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.EditText;
+import android.content.pm.ActivityInfo;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -57,6 +58,8 @@ public class MainActivity extends AppCompatActivity implements SensorEventListen
 
         accelerometer = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
         gyro = sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE);
+
+        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
     }
 
     public void startRecording(View view) {
@@ -131,7 +134,7 @@ public class MainActivity extends AppCompatActivity implements SensorEventListen
             float x = event.values[0];
             float y = event.values[1];
             float z = event.values[2];
-            String result = x + "," + y + "," + z + "\n";
+            String result = event.timestamp / 1000000 + "," + x + "," + y + "," + z + "\n";
             //Log.d(TAG, "Sensor " + event.sensor.getType() + ": " + result);
             targetList.add(result);
         }
@@ -147,7 +150,7 @@ public class MainActivity extends AppCompatActivity implements SensorEventListen
         Log.d(TAG, "onTouch: " + event.getAction());
         if (event.getAction() == MotionEvent.ACTION_DOWN && started) {
             Point p = getRelativePosition(boundView, event);
-            String result = p.x + "," + p.y + "\n";
+            String result = event.getEventTime() + "," + p.x + "," + p.y + "\n";
             Log.d(TAG, "onTouch: " + result);
             positionValues.add(result);
             Log.d(TAG, "totalPos: " + positionValues.size());

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,7 +14,9 @@
     <EditText
         android:id="@+id/filename"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:textSize="18sp"
+        android:hint="Subject name" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -49,4 +51,47 @@
             android:layout_height="20dp"
             android:background="#FF0000" />
     </LinearLayout>
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ToggleButton
+            android:text="right"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/isRightHand"
+            android:checked="true"
+            android:textOn="right"
+            android:textOff="left" />
+
+        <ToggleButton
+            android:text="table"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/isTable"
+            android:textOff="holding"
+            android:textOn="table"
+            android:checked="true" />
+
+        <ToggleButton
+            android:text="thumb"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/isThumb"
+            android:textOn="thumb"
+            android:textOff="index"
+            android:checked="true" />
+
+        <ToggleButton
+            android:text="nail"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/isNail"
+            android:checked="true"
+            android:textOn="nail"
+            android:textOff="no nail" />
+    </LinearLayout>
+
 </LinearLayout>


### PR DESCRIPTION
Screen flip interrupts data collecting. Therefore, the activity is set
forcely to portrait mode.

Include timestamp as the first column of data row, in millisecond.